### PR TITLE
add yml key for drc decks, add hook to turn off false rules for Pegasus DRC 

### DIFF
--- a/hammer/technology/sky130/__init__.py
+++ b/hammer/technology/sky130/__init__.py
@@ -221,20 +221,13 @@ class SKY130Tech(HammerTechnology):
             ]
             drc_decks = [
                 DRCDeck(
-                    tool_name="calibre",
-                    deck_name="calibre_drc",
-                    path="$SKY130_NDA/s8/V2.0.1/DRC/Calibre/s8_drcRules",
-                ),
-                DRCDeck(
-                    tool_name="klayout",
-                    deck_name="klayout_drc",
-                    path="$SKY130A/libs.tech/klayout/drc/sky130A.lydrc",
-                ),
-                DRCDeck(
-                    tool_name="pegasus",
-                    deck_name="pegasus_drc",
-                    path="$SKY130_CDS/Sky130_DRC/sky130_rev_0.0_2.2.drc.pvl",
-                ),
+                    tool_name=self.get_setting("vlsi.core.drc_tool").replace(
+                        "hammer.drc.", ""
+                    ),
+                    deck_name=f"{self.get_setting('vlsi.core.drc_tool').replace('hammer.drc.', '')}_drc",
+                    path=path,
+                )
+                for path in self.get_setting("technology.sky130.sky130_drc_decks")
             ]
 
         elif slib == "sky130_scl":
@@ -300,17 +293,13 @@ class SKY130Tech(HammerTechnology):
             ]
             drc_decks = [
                 DRCDeck(
-                    tool_name="calibre",
-                    deck_name="calibre_drc",
-                    path="$SKY130_NDA/s8/V2.0.1/DRC/Calibre/s8_drcRules",
-                ),
-                DRCDeck(
-                    tool_name="pegasus",
-                    deck_name="pegasus_drc",
-                    path=os.path.join(
-                        SKY130_CDS, "Sky130_DRC", "sky130_rev_0.0_2.2.drc.pvl"
+                    tool_name=self.get_setting("vlsi.core.drc_tool").replace(
+                        "hammer.drc.", ""
                     ),
-                ),
+                    deck_name=f"{self.get_setting('vlsi.core.drc_tool').replace('hammer.drc.', '')}_drc",
+                    path=path,
+                )
+                for path in self.get_setting("technology.sky130.sky130_drc_decks")
             ]
 
         else:
@@ -850,6 +839,11 @@ class SKY130Tech(HammerTechnology):
                 "generate_drc_ctl_file", pegasus_drc_blackbox_io_cells
             )
         )
+        pegasus_hooks.append(
+            HammerTool.make_post_insertion_hook(
+                "generate_drc_ctl_file", false_rules_off
+            )
+        )
         hooks = {"calibre": calibre_hooks, "pegasus": pegasus_hooks}
         return hooks.get(tool_name, [])
 
@@ -1149,6 +1143,27 @@ def pegasus_drc_blackbox_io_cells(ht: HammerTool) -> bool:
         f.write(drc_box)
     return True
 
+def false_rules_off(x: HammerTool) -> bool:
+    # in sky130_rev_0.0_2.3 rules, cadence included a .cfg to turn off false rules - this typically has to be loaded via the GUI but this step hacks the flags into pegasusdrcctl and turns the false rules off
+    # if FALSEOFF is defined, the rules are turned off
+    # docs for hooks: /scratch/ee198-20-aaf/barduino-ofot/vlsi/hammer/hammer/drc/pegasus/README.md
+    drc_box = """
+//=== Configurator controls ===
+//  Turn OFF rules that may be inaccurate due to out-of-date DRM information 
+//      (these rules are on by default and may produce false violations)     
+#DEFINE FALSEOFF
+//  Recommended Rules (RC,RR) & Guidelines (NC)
+#UNDEFINE RC
+#UNDEFINE NC
+//  Optional Switches 
+#UNDEFINE frontend
+#UNDEFINE backend
+//=== End of configurator controls ===
+    """
+    run_file = x.drc_ctl_file  # type: ignore
+    with open(run_file, "a") as f:
+        f.write(drc_box)
+    return True
 
 def pegasus_drc_blackbox_srams(ht: HammerTool) -> bool:
     assert isinstance(ht, HammerDRCTool), "Exlude SRAMs only in DRC"

--- a/hammer/technology/sky130/__init__.py
+++ b/hammer/technology/sky130/__init__.py
@@ -227,7 +227,7 @@ class SKY130Tech(HammerTechnology):
                     deck_name=f"{self.get_setting('vlsi.core.drc_tool').replace('hammer.drc.', '')}_drc",
                     path=path,
                 )
-                for path in self.get_setting("technology.sky130.sky130_drc_decks")
+                for path in self.get_setting("technology.sky130.drc_deck_sources")
             ]
 
         elif slib == "sky130_scl":
@@ -299,7 +299,7 @@ class SKY130Tech(HammerTechnology):
                     deck_name=f"{self.get_setting('vlsi.core.drc_tool').replace('hammer.drc.', '')}_drc",
                     path=path,
                 )
-                for path in self.get_setting("technology.sky130.sky130_drc_decks")
+                for path in self.get_setting("technology.sky130.drc_deck_sources")
             ]
 
         else:

--- a/hammer/technology/sky130/defaults.yml
+++ b/hammer/technology/sky130/defaults.yml
@@ -28,6 +28,8 @@ technology.sky130:
   
   pdk_home: "${technology.sky130.sky130_nda}/s8/V2.0.1" # Shouldn't need to change these
   pdk_home_meta: lazysubst
+  drc_deck_sources: # DRC decks, one element for each deck
+    - "${technology.sky130.sky130_cds}/Sky130_DRC/sky130_rev_0.0_2.6.drc.pvl"
   lvs_deck_sources: 
     - "${technology.sky130.pdk_home}/LVS/Calibre/lvsControlFile_s8"
   lvs_deck_sources_meta: lazysubst

--- a/hammer/technology/sky130/defaults_types.yml
+++ b/hammer/technology/sky130/defaults_types.yml
@@ -27,6 +27,7 @@ technology.sky130:
 
   # Shouldn't need to change these
   pdk_home: Optional[str]
+  drc_deck_sources: Optional[list[str]]
   lvs_deck_sources: Optional[list[str]]
 
   # Path to IO file


### PR DESCRIPTION
<!-- Provide a brief description of the PR immediately below this comment, if the title is insufficient -->

Adds 2 things:
* Add ability for users to specify their DRC deck via `sky130_drc_decks: ["", "", ...]` in tech-sky130.yml (one string containing path to deck for each deck) - it'll be added to the specific tool's `drc_decks` list automatically given `vlsi.core.drc_tool` is set in the tools.yml
    * corresponding tech yml is here: https://github.com/jimfangx/barduino-vlsi/blob/26184e72223ceb2e8631cebbd0d2f6fcb7a07dd0/vlsi/tech-sky130-inst.yml#L24-L26
* Add hook for pegasus decks to turn false rules off. -- If you are using the Cadence DRC Deck sky130_rev_0.0_2.3, Cadence included a .cfg to turn off false rules - this typically has to be loaded via the GUI but this hook inserts the flags into pegasusdrcctl and turns the false rules off.
    * if `FALSEOFF` is defined, the rules are turned off

**Related PRs / Issues**
<!-- List any related PRs/issues here, if applicable -->

<!-- choose one -->
**Type of change**:
- [ ] Bug fix
- [x] New feature
- [ ] Other enhancement

<!-- choose one -->
**Impact**:
- [ ] Change to core Hammer
- [x] Change to a Hammer plugin
- [ ] Other

<!-- must be filled out completely to be considered for merging -->
**Contributor Checklist**:
- [ ] Did you set `master` as the base branch?
- [ ] Did you state the type-of-change/impact?
- [ ] Did you delete any extraneous prints/debugging code?
- [ ] (If applicable) Did you add documentation for the feature?
- [ ] (If applicable) Did you update the `poetry.lock` file if you updated the requirements in `pyproject.toml`?
- [ ] (If applicable) Did you add a unit test demonstrating the PR?
- [ ] (If applicable) Did you run this through the e2e integration tests?
- [ ] (If applicable) Did you update the submodules in `e2e/` if this feature depends on updated plugins?